### PR TITLE
Some fixes for OTP 21

### DIFF
--- a/erlang/src/tcpcall_server.erl
+++ b/erlang/src/tcpcall_server.erl
@@ -525,14 +525,14 @@ deliver_request(FunObject, RequestRef, Request)
                           queue_reply(
                             ServerPid, RequestRef, Reply)
                   catch
-                      ExcType:ExcReason ->
+                      ExcType:ExcReason:StackTrace ->
                           queue_error(
                             ServerPid, RequestRef,
                             {crashed,
                              [{type, ExcType},
                               {reason, ExcReason},
                               {stacktrace,
-                               erlang:get_stacktrace()}]})
+                               StackTrace}]})
                   end
           end),
     ok.


### PR DESCRIPTION
Fix for erlang:get_stacktrace/0: deprecated.